### PR TITLE
feat: add basic song list UI with dummy data generation

### DIFF
--- a/GuitarSongsTracker/ContentView.swift
+++ b/GuitarSongsTracker/ContentView.swift
@@ -13,17 +13,69 @@ struct ContentView: View {
     @Environment(\.modelContext) var modelContext
     
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationStack {
+            List {
+                ForEach(songs) { song in
+                    // TODO: Refactor list items into separate SongRowView struct
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(song.title)
+                            .font(.title2)
+                        Text(song.artist)
+                            .font(.title3)
+                        Text(song.status)
+                            .font(.body)
+                        Text(song.addedDate.formatted(date: .abbreviated, time: .omitted))
+                    }.padding(.vertical, 4)
+                }
+            }
+            .navigationTitle("Song Tracker")
+            .toolbar {
+                ToolbarItem {
+                    Button {
+                        addDummyData()
+                    } label: {
+                        Label("Add Song", systemImage: "plus")
+                    }
+                }
+            }
         }
-        .padding()
+    }
+    
+    private func addDummyData() {
+        let dummySongs = [
+            Song(title: "Wonderwall",
+                 artist: "Oasis",
+                 status: "Learning"),
+            Song(title: "Hotel California",
+                 artist: "Eagles",
+                 status: "Not Started"),
+            Song(title: "Sweet Child O' Mine",
+                 artist: "Guns N' Roses",
+                 status: "Can Play"),
+            Song(title: "Black",
+                 artist: "Pearl Jam",
+                 status: "Mastered"),
+            Song(title: "Stairway to Heaven",
+                 artist: "Led Zeppelin",
+                 status: "Not Started"),
+            Song(title: "Creep",
+                 artist: "Radiohead",
+                 status: "Learning"),
+            Song(title: "Wish You Were Here",
+                 artist: "Pink Floyd",
+                 status: "Can Play"),
+            Song(title: "Under the Bridge",
+                 artist: "Red Hot Chili Peppers",
+                 status: "Learning")
+        ]
+        
+        for song in dummySongs {
+            modelContext.insert(song)
+        }
     }
 }
 
 #Preview {
     ContentView()
-        .modelContainer(for: Song.self, inMemory: true) 
+        .modelContainer(for: Song.self, inMemory: true)
 }


### PR DESCRIPTION
**What this does**
- Adds button to add dummy data to storage
- Displays data in a simple list from storage

**Changes made**
- Add dummy data function
- Add basic list UI

**Next steps**
- Refine UI for song list

Closes #3 