### PR TITLE
feat: implement settings page with dark mode theme option

### DIFF
--- a/GuitarSongsTracker/ContentView.swift
+++ b/GuitarSongsTracker/ContentView.swift
@@ -48,12 +48,23 @@ struct ContentView: View {
             .navigationSubtitle("\(filteredSongs.count) \(filteredSongs.count == 1 ? "Song" : "Songs")")
             .toolbar {
                 ToolbarItem (placement: .topBarTrailing) {
-                        Button {
-                            showSheet = true
-                            selectedSong = nil
-                        } label: {
-                            Label("Add Song", systemImage: "plus")
-                        }
+                    NavigationLink(destination: SettingsView()) {
+                        Label("Settings", systemImage: "gear")
+                            .font(.title2)
+                            .labelStyle(.iconOnly)
+                    }
+                }
+                ToolbarItem(placement: .bottomBar) {
+                    Spacer()
+                }
+                ToolbarItem (placement: .bottomBar) {
+                    Button {
+                        showSheet = true
+                        selectedSong = nil
+                    } label: {
+                        Label("Add Song", systemImage: "plus")
+                    }.buttonStyle(.glassProminent)
+                        .tint(.indigo)
                 }
             }
         }

--- a/GuitarSongsTracker/GuitarSongsTrackerApp.swift
+++ b/GuitarSongsTracker/GuitarSongsTrackerApp.swift
@@ -9,10 +9,23 @@ import SwiftUI
 
 @main
 struct GuitarSongsTrackerApp: App {
+    @AppStorage("appearanceSetting") private var theme: String = "system"
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .preferredColorScheme(colorSchemeFrom(theme))
         }
-        .modelContainer(for: Song.self)
+    }
+
+    func colorSchemeFrom(_ value: String) -> ColorScheme? {
+        switch value {
+        case "light":
+            return .light
+        case "dark":
+            return .dark
+        default:
+            return nil
+        }
     }
 }

--- a/GuitarSongsTracker/Views/AddSongView.swift
+++ b/GuitarSongsTracker/Views/AddSongView.swift
@@ -80,7 +80,8 @@ struct AddSongView: View {
                             modelContext.insert(newSong)
                         }
                         dismiss()
-                    }
+                    }.buttonStyle(.glassProminent)
+                        .tint(.indigo)
                     .disabled(!canSave)
                 }
             }

--- a/GuitarSongsTracker/Views/SettingsView.swift
+++ b/GuitarSongsTracker/Views/SettingsView.swift
@@ -1,0 +1,32 @@
+//
+//  SettingsView.swift
+//  GuitarSongsTracker
+//
+//  Created by Craig Williams on 29/08/2025.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+
+    @AppStorage("appearanceSetting") private var theme: String = "system"
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Picker("Appearance", selection: $theme) {
+                    Text("System").tag("system")
+                    Text("Light").tag("light")
+                    Text("Dark").tag("dark")
+                }
+                .pickerStyle(.segmented)
+            }
+        }
+        .navigationTitle("Settings")
+    }
+}
+
+
+#Preview {
+    SettingsView()
+}


### PR DESCRIPTION
**What this does**
- Adds settings view with navigation from home page
- Adds app storage for storing theme setting
- Add picker for system, dark and light mode settings
- Enhances UI with tint colours on primary buttons

**Changes made**
- Created SettingsView page
- Added .indigo to primary buttons like "add" and "save"
- Created AppStorage variable to store user setting
- Added helper function to convert AppStorage string values to ColorScheme for theme application

Closes #15 
